### PR TITLE
Add scanpy to the requiremeents_tests.txt

### DIFF
--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -9,3 +9,4 @@ xlrd
 joblib
 black
 boltons
+scanpy


### PR DESCRIPTION
Tests that verify that anndata works w/ scanpy only run if it is installed.  It should be installed in the CI tests to prevent a regression that breaks integration with scanpy.